### PR TITLE
fix: use networking v1 ingress in chapter 5 tutorials ingress manifests

### DIFF
--- a/chapter-05/tutorial5.2.1/green_ingress.yaml
+++ b/chapter-05/tutorial5.2.1/green_ingress.yaml
@@ -1,16 +1,19 @@
-apiVersion: extensions/v1beta1 #networking.k8s.io/v1beta 
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo-ingress
 spec:
   rules:
-  - host: demo.info
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: green-service
-          servicePort: 80
+    - host: demo.info
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: green-service
+                port:
+                  number: 80
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/chapter-05/tutorial5.2.2/ingress.yaml
+++ b/chapter-05/tutorial5.2.2/ingress.yaml
@@ -1,16 +1,19 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo-ingress
 spec:
   rules:
-  - host: demo.info
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: demo-service
-          servicePort: 80
+    - host: demo.info
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: demo-service
+                port:
+                  number: 80
 ---
 apiVersion: v1
 data:

--- a/chapter-05/tutorial5.3.1/blue_ingress.yaml
+++ b/chapter-05/tutorial5.3.1/blue_ingress.yaml
@@ -1,16 +1,19 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo-ingress
 spec:
   rules:
-  - host: demo.info
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: blue-service
-          servicePort: 80
+    - host: demo.info
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: blue-service
+                port:
+                  number: 80
 ---
 apiVersion: v1
 data:

--- a/chapter-05/tutorial5.3.1/canary_ingress.yaml
+++ b/chapter-05/tutorial5.3.1/canary_ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: canary-ingress
@@ -7,13 +7,16 @@ metadata:
     nginx.ingress.kubernetes.io/canary-weight: "10"
 spec:
   rules:
-  - host: demo.info
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: green-service
-          servicePort: 80
+    - host: demo.info
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: green-service
+                port:
+                  number: 80
 ---
 apiVersion: v1
 data:

--- a/chapter-05/tutorial5.3.2/ingress.yaml
+++ b/chapter-05/tutorial5.3.2/ingress.yaml
@@ -1,16 +1,19 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo-ingress
 spec:
   rules:
-  - host: demo.info
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: demo-service
-          servicePort: 80
+    - host: demo.info
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: demo-service
+                port:
+                  number: 80
 ---
 apiVersion: v1
 data:

--- a/chapter-05/tutorial5.4.1/ingress.yaml
+++ b/chapter-05/tutorial5.4.1/ingress.yaml
@@ -1,16 +1,19 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo-ingress
 spec:
   rules:
-  - host: demo.info
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: demo-service
-          servicePort: 80
+    - host: demo.info
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: demo-service
+                port:
+                  number: 80
 ---
 apiVersion: v1
 data:


### PR DESCRIPTION
This fixes the following error which is raised when trying to apply old `extensions/v1beta1` spec.

![image](https://github.com/user-attachments/assets/b248e048-c860-4e11-b9bf-ae8f9df5803b)
